### PR TITLE
Allow files that end with `.html`.

### DIFF
--- a/lib/cloudfront_link_checker.rb
+++ b/lib/cloudfront_link_checker.rb
@@ -11,7 +11,7 @@ class CloudfrontLinkChecker
         results.each do |line|
           links = line.match(/href=(["'])(.*?)\1/i)[2]
           exclude_start_with_list = ["https:", "#", "mailto:", "tel:"]
-          exclude_endings = [".ico", ".png", ".css", "/#contact-us", ".pdf"]
+          exclude_endings = [".ico", ".png", ".css", "/#contact-us", ".pdf", ".html"]
           if !links.start_with?(*exclude_start_with_list) && !links.end_with?(*exclude_endings)
             if !links.start_with?("/") || !links.end_with?("/")
               bad_links.push(links)

--- a/spec/cloudfront_link_checker_spec.rb
+++ b/spec/cloudfront_link_checker_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CloudfrontLinkChecker do
       allow(Dir).to receive(:chdir) { |&block| block.call() }
       allow(Dir).to receive(:glob).and_return(["somefile.html"])
       allow(File).to receive(:readlines).and_return(['<a href="/some.pdf">Link to PDF</a>'])
+      allow(File).to receive(:readlines).and_return(['<a href="/community/2019/05/22/kcdc.html">html Link</a>'])
 
       expect(CloudfrontLinkChecker.scan_files('app/_site')).to be_nil
     end


### PR DESCRIPTION
When we remove permalinks, Jekyll creates the path for all posts that ends with .html. Our build is breaking until we can use the latest version of this gem.